### PR TITLE
Fix some gestures don't work on Android

### DIFF
--- a/src/utils/GestureHandler.tsx
+++ b/src/utils/GestureHandler.tsx
@@ -74,19 +74,21 @@ export function GestureHandler({
     }
   };
 
+  const combinedGestures = Gesture.Exclusive(
+    swipeLeft,
+    swipeRight,
+    swipeUp,
+    swipeDown,
+    longPress,
+    doubleTap,
+    singleTap
+  );
+  
   if (Platform.OS === 'ios') {
     return (
       <GestureHandlerRootView style={{ flex: 1 }}>
         <GestureDetector
-          gesture={Gesture.Exclusive(
-            swipeLeft,
-            swipeRight,
-            swipeUp,
-            swipeDown,
-            longPress,
-            doubleTap,
-            singleTap
-          )}
+          gesture={combinedGestures}
         >
           <TouchableWithoutFeedback
             style={{ width, height }}
@@ -101,7 +103,7 @@ export function GestureHandler({
   }
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <GestureDetector gesture={Gesture.Exclusive(swipeLeft, swipeRight)}>
+      <GestureDetector gesture={combinedGestures}>
         <View style={{ width, height }}>{children}</View>
       </GestureDetector>
     </GestureHandlerRootView>


### PR DESCRIPTION
This PR addresses an issue where certain gestures (swipe up, swipe down, long press, double tap, and single tap) were not functioning correctly on Android.

Key Changes:
- Introduced combinedGestures variable to consolidate all gestures into a single exclusive gesture set.
- Updated the GestureDetector component to use combinedGestures for gesture detection on both iOS and Android.